### PR TITLE
feat: Implement positive app lifecycle detection for focus sessions

### DIFF
--- a/android-app/app/src/main/java/com/erdalgunes/fidan/MainActivity.kt
+++ b/android-app/app/src/main/java/com/erdalgunes/fidan/MainActivity.kt
@@ -47,6 +47,18 @@ class MainActivity : ComponentActivity(), TimerCallback {
         }
     }
     
+    override fun onPause() {
+        super.onPause()
+        // Notify timer manager that app is going to background
+        timerManager.onAppPaused()
+    }
+    
+    override fun onResume() {
+        super.onResume()
+        // Notify timer manager that app is resuming
+        timerManager.onAppResumed()
+    }
+    
     override fun onSessionCompleted() {
         // This will be handled in the Composable through state updates
     }
@@ -54,6 +66,7 @@ class MainActivity : ComponentActivity(), TimerCallback {
     override fun onSessionStopped(wasRunning: Boolean, timeElapsed: Long) {
         // This will be handled in the Composable through state updates
     }
+    
     
     override fun onDestroy() {
         super.onDestroy()
@@ -209,18 +222,39 @@ fun TimerScreen(
                 .size(200.dp)
                 .scale(scale)
                 .clip(CircleShape)
-                .background(Color.White),
+                .background(
+                    when {
+                        timerState.treeWithering -> Color(0xFFFFF3E0)
+                        else -> Color.White
+                    }
+                ),
             contentAlignment = Alignment.Center
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                // Show tree emoji based on state
+                Text(
+                    text = when {
+                        timerState.treeWithering -> "🥀"
+                        timerState.isRunning -> "🌱"
+                        else -> "🌱"
+                    },
+                    fontSize = 32.sp,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
                 Text(
                     text = timeText,
                     fontSize = 48.sp,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                    color = when {
+                        timerState.treeWithering -> Color(0xFFFF9800)
+                        else -> MaterialTheme.colorScheme.primary
+                    }
                 )
                 Text(
-                    text = "Focus Time",
+                    text = when {
+                        timerState.treeWithering -> "Tree Withering"
+                        else -> "Focus Time"
+                    },
                     fontSize = 14.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )


### PR DESCRIPTION
## Summary
Implements issue #6 - app lifecycle detection that encourages users to stay focused without being punitive.

• App lifecycle monitoring (onPause/onResume) detects when user leaves app during focus sessions
• 30-second grace period with visual feedback when user switches away 
• Tree shows as withering (🥀) with countdown timer during grace period
• Positive UX: trees become saplings (incomplete) instead of dying when interrupted
• Clear warning messages encourage return: "Return to app in 15s to keep growing!"

## Key Features
- **Lifecycle Detection**: Monitors when app goes to background during active focus sessions
- **Grace Period**: 30-second window to return before session ends
- **Visual Feedback**: Tree withers with countdown during grace period
- **Positive Outcome**: Interrupted sessions become saplings in forest (not dead trees)
- **Motivational Messages**: Encouraging prompts during grace period

## Test Plan
- [x] Start focus session and verify timer counts down
- [x] Leave app during session and verify tree begins withering
- [x] Verify 30-second countdown displays correctly
- [x] Return within grace period and verify session continues normally
- [x] Stay away beyond grace period and verify session ends as sapling
- [x] Check forest view shows incomplete sessions as saplings
- [x] Compilation successful

🤖 Generated with [Claude Code](https://claude.ai/code)