### PR TITLE
ci: Add automated PR size checks to prevent scope creep

### DIFF
--- a/.github/pr-scope-guidelines.md
+++ b/.github/pr-scope-guidelines.md
@@ -1,0 +1,106 @@
+# Pull Request Scope Guidelines
+
+## PR Size Limits
+
+To maintain code quality and ensure efficient reviews, we enforce the following PR size limits:
+
+### Hard Limits (PR will be blocked)
+- **Maximum changes**: 1,500 lines (additions + deletions)
+- **Maximum files**: 20 files changed
+
+### Warning Thresholds
+- **Warning at**: 1,000 lines or 15 files
+- **Ideal size**: < 500 lines, < 10 files
+
+## Size Categories
+
+PRs are automatically labeled based on total changes:
+
+| Label | Lines Changed | Review Time | Description |
+|-------|--------------|-------------|-------------|
+| `size/XS` | < 50 | 5-10 min | Tiny changes, typos, config updates |
+| `size/S` | 50-199 | 10-20 min | Small features or bug fixes |
+| `size/M` | 200-499 | 20-40 min | Medium features, refactoring |
+| `size/L` | 500-999 | 40-60 min | Large features (consider splitting) |
+| `size/XL` | 1000-1499 | 1-2 hours | Very large (should be split) |
+| `size/XXL` | 1500+ | Blocked | Too large, must be split |
+
+## How to Split Large PRs
+
+### 1. By Feature Layer
+Split vertically through the application stack:
+- PR 1: Backend/API changes
+- PR 2: Service/business logic layer
+- PR 3: UI/frontend changes
+- PR 4: Tests and documentation
+
+### 2. By Functionality
+Split horizontally by feature:
+- PR 1: Core functionality
+- PR 2: Enhanced features
+- PR 3: Edge cases and error handling
+- PR 4: Performance optimizations
+
+### 3. By File Type
+Group similar changes:
+- PR 1: Model/data changes
+- PR 2: UI components
+- PR 3: Configuration and setup
+- PR 4: Tests
+
+## Best Practices
+
+### ✅ DO
+- Keep PRs focused on a single issue or feature
+- Include tests with implementation
+- Update documentation in the same PR
+- Use feature flags for incremental rollout
+- Create draft PRs early for feedback
+
+### ❌ DON'T
+- Mix unrelated changes in one PR
+- Include auto-generated files (unless necessary)
+- Refactor while adding features (separate PRs)
+- Bundle multiple bug fixes together
+- Include debugging code or console logs
+
+## Examples
+
+### Good PR Scope
+```
+feat: Add user authentication
+- 8 files changed
+- 350 lines added, 50 deleted
+- Includes implementation, tests, and docs
+- Single, clear purpose
+```
+
+### Bad PR Scope
+```
+feat: Multiple improvements
+- 45 files changed
+- 3000 lines added, 500 deleted
+- Mixes authentication, UI updates, bug fixes
+- Multiple unrelated changes
+```
+
+## Exceptions
+
+Large PRs may be acceptable for:
+- Initial project setup
+- Major dependency updates (with justification)
+- Generated code (should be marked as such)
+- Large-scale automated refactoring (with separate review)
+
+In these cases, add a comment explaining why the PR couldn't be split.
+
+## Enforcement
+
+The PR size check workflow will:
+1. Analyze every PR automatically
+2. Add size labels for visibility
+3. Post analysis comments with recommendations
+4. Block PRs exceeding hard limits
+5. Warn about PRs approaching limits
+
+This helps maintain code quality, review efficiency, and project velocity.

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,0 +1,204 @@
+name: PR Size and Scope Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-pr-size:
+    name: Check PR Size
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Get PR Stats
+        id: pr-stats
+        run: |
+          # Get the number of changed files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} | wc -l)
+          echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
+          
+          # Get additions and deletions
+          ADDITIONS=$(git diff --numstat origin/${{ github.base_ref }}...${{ github.sha }} | awk '{ additions += $1 } END { print additions }')
+          DELETIONS=$(git diff --numstat origin/${{ github.base_ref }}...${{ github.sha }} | awk '{ deletions += $2 } END { print deletions }')
+          TOTAL_CHANGES=$((ADDITIONS + DELETIONS))
+          
+          echo "additions=$ADDITIONS" >> $GITHUB_OUTPUT
+          echo "deletions=$DELETIONS" >> $GITHUB_OUTPUT
+          echo "total_changes=$TOTAL_CHANGES" >> $GITHUB_OUTPUT
+          
+      - name: Check PR Size Limits
+        id: check-size
+        run: |
+          TOTAL_CHANGES=${{ steps.pr-stats.outputs.total_changes }}
+          CHANGED_FILES=${{ steps.pr-stats.outputs.changed_files }}
+          
+          # Define thresholds
+          MAX_CHANGES=1500
+          MAX_FILES=20
+          WARNING_CHANGES=1000
+          WARNING_FILES=15
+          
+          STATUS="ok"
+          MESSAGE=""
+          
+          if [ "$TOTAL_CHANGES" -gt "$MAX_CHANGES" ] || [ "$CHANGED_FILES" -gt "$MAX_FILES" ]; then
+            STATUS="too_large"
+            MESSAGE="❌ PR is too large! Changes: $TOTAL_CHANGES (max: $MAX_CHANGES), Files: $CHANGED_FILES (max: $MAX_FILES)"
+          elif [ "$TOTAL_CHANGES" -gt "$WARNING_CHANGES" ] || [ "$CHANGED_FILES" -gt "$WARNING_FILES" ]; then
+            STATUS="warning"
+            MESSAGE="⚠️ PR is getting large. Changes: $TOTAL_CHANGES, Files: $CHANGED_FILES. Consider splitting if it grows more."
+          else
+            STATUS="ok"
+            MESSAGE="✅ PR size is good. Changes: $TOTAL_CHANGES, Files: $CHANGED_FILES"
+          fi
+          
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+          echo "message=$MESSAGE" >> $GITHUB_OUTPUT
+          
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ steps.check-size.outputs.status }}';
+            const message = '${{ steps.check-size.outputs.message }}';
+            const additions = '${{ steps.pr-stats.outputs.additions }}';
+            const deletions = '${{ steps.pr-stats.outputs.deletions }}';
+            const files = '${{ steps.pr-stats.outputs.changed_files }}';
+            
+            let comment = `## 📊 PR Size Analysis\n\n`;
+            comment += `${message}\n\n`;
+            comment += `### Statistics\n`;
+            comment += `- **Files Changed**: ${files}\n`;
+            comment += `- **Lines Added**: +${additions}\n`;
+            comment += `- **Lines Deleted**: -${deletions}\n`;
+            comment += `- **Total Changes**: ${parseInt(additions) + parseInt(deletions)}\n\n`;
+            
+            if (status === 'too_large') {
+              comment += `### 🔄 Recommended Actions\n`;
+              comment += `1. **Split this PR** into smaller, focused changes\n`;
+              comment += `2. **Group related changes** together\n`;
+              comment += `3. **Aim for <1000 lines** per PR for easier review\n\n`;
+              comment += `### Why Smaller PRs?\n`;
+              comment += `- ✅ Faster review cycles (15-30 min vs hours)\n`;
+              comment += `- ✅ Easier to identify issues\n`;
+              comment += `- ✅ Lower risk of merge conflicts\n`;
+              comment += `- ✅ Better commit history\n`;
+              comment += `- ✅ Can be merged incrementally\n`;
+            } else if (status === 'warning') {
+              comment += `### 💡 Tips\n`;
+              comment += `- Consider if this PR has a single, clear purpose\n`;
+              comment += `- Check if any changes could be split into follow-up PRs\n`;
+              comment += `- Ensure all changes are related to the PR title\n`;
+            }
+            
+            // Find and update or create comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('PR Size Analysis')
+            );
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }
+            
+            // Fail the check if PR is too large
+            if (status === 'too_large') {
+              core.setFailed('PR exceeds size limits. Please split into smaller PRs.');
+            }
+            
+      - name: Label PR by Size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const total = ${{ steps.pr-stats.outputs.total_changes }};
+            let label = '';
+            
+            if (total < 50) {
+              label = 'size/XS';
+            } else if (total < 200) {
+              label = 'size/S';
+            } else if (total < 500) {
+              label = 'size/M';
+            } else if (total < 1000) {
+              label = 'size/L';
+            } else if (total < 1500) {
+              label = 'size/XL';
+            } else {
+              label = 'size/XXL';
+            }
+            
+            // Remove any existing size labels
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            for (const existingLabel of labels.data) {
+              if (existingLabel.name.startsWith('size/')) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: existingLabel.name,
+                });
+              }
+            }
+            
+            // Add the new size label
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [label]
+              });
+            } catch (error) {
+              console.log('Label might not exist, creating it...');
+              // Create label if it doesn't exist
+              const colors = {
+                'size/XS': '69db7c',
+                'size/S': '40c057',
+                'size/M': 'fab005',
+                'size/L': 'fd7e14',
+                'size/XL': 'f76707',
+                'size/XXL': 'e03131'
+              };
+              
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: colors[label] || 'cccccc'
+              });
+              
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [label]
+              });
+            }

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   check-pr-size:
     name: Check PR Size


### PR DESCRIPTION
## Summary
This PR adds automated CI/CD checks to prevent future scope creep by enforcing PR size limits.

## Problem Solved
- Large PRs like #52 (7,642 lines) are difficult to review
- No automated enforcement of PR scope guidelines
- Review fatigue from oversized pull requests
- Higher risk of bugs in large changes

## Solution
✅ **Automated PR Size Analysis**
- Runs on every pull request automatically
- Calculates lines changed and files modified
- Posts detailed analysis as PR comment
- Updates comment on subsequent pushes

✅ **Size Enforcement**
- **Hard limits**: 1,500 lines, 20 files (PR blocked)
- **Warning threshold**: 1,000 lines, 15 files
- Clear feedback on how to split large PRs

✅ **Automatic Labeling**
- `size/XS` to `size/XXL` labels
- Visual indicator of PR complexity
- Helps reviewers prioritize

✅ **Documentation**
- Comprehensive PR scope guidelines
- Examples of good vs bad PR scope
- Instructions for splitting large PRs

## Files Added
- `.github/workflows/pr-size-check.yml` - GitHub Actions workflow
- `.github/pr-scope-guidelines.md` - Documentation and guidelines

## Benefits
- 📊 Enforces manageable PR sizes
- ⏱️ Reduces review time (target: 15-60 min)
- 🐛 Easier to identify and fix issues
- 📝 Better commit history
- 🚀 Faster iteration cycles

## Testing
This workflow will be tested on this very PR, demonstrating the size analysis in action.

Fixes the scope creep issues identified during PR reviews.